### PR TITLE
Inline Terraform State Policies

### DIFF
--- a/examples/role/main.tf
+++ b/examples/role/main.tf
@@ -10,7 +10,7 @@ module "common_provider_example" {
   // Relative path to the repository for the given provider
   repository = "appvia/something"
   // Set the permission boundary for both the read-only and read-write role
-  permission_boundary = "AdministratorAccess"
+  permission_boundary_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
   // List of policy ARNs to attach to the read-only role
   read_only_policy_arns = [
     "arn:aws:iam::aws:policy/ReadOnlyAccess",

--- a/modules/role/checks.tf
+++ b/modules/role/checks.tf
@@ -21,3 +21,17 @@ check "policy_config" {
     error_message = "At least one of 'read_write_policy_arns' or 'read_write_inline_policies' must be specified"
   }
 }
+
+check "permission_boundary" {
+  # Either permission_boundary or permission_boundary_arn must be specified
+  assert {
+    condition     = !(var.permission_boundary == null && var.permission_boundary_arn == null)
+    error_message = "Either 'permission_boundary' or 'permission_boundary_arn' must be specified"
+  }
+
+  # Both permission_boundary and permission_boundary_arn cannot be specified 
+  assert {
+    condition     = !(var.permission_boundary != null && var.permission_boundary_arn != null)
+    error_message = "Only one of 'permission_boundary' or 'permission_boundary_arn' may be specified"
+  }
+}

--- a/modules/role/locals.tf
+++ b/modules/role/locals.tf
@@ -1,5 +1,8 @@
 
 locals {
+  # The current account ID 
+  account_id = data.aws_caller_identity.current.account_id
+  ## The common OIDC providers to use 
   common_providers = {
     github = {
       url = "https://token.actions.githubusercontent.com"
@@ -25,8 +28,10 @@ locals {
       subject_tag_mapping    = "project_path:{repo}:ref_type:{type}:ref:{ref}"
     }
   }
+  # The devired permission_boundary arn 
+  permission_boundary_by_name = var.permission_boundary != null ? format("arn:aws:iam::%s:policy/%s", local.account_id, var.permission_boundary) : null
   # The full ARN of the permission boundary to attach to the role
-  permission_boundary_arn = format("arn:aws:iam::%s:policy/%s", data.aws_caller_identity.current.account_id, var.permission_boundary)
+  permission_boundary_arn = var.permission_boundary_arn == null ? local.permission_boundary_by_name : var.permission_boundary_arn
 }
 
 locals {
@@ -40,7 +45,6 @@ locals {
 
   # Keys to search for in the subject mapping template
   template_keys_regex = "{(repo|type|ref)}"
-
-  account_id      = data.aws_caller_identity.current.account_id
+  # The prefix for the terraform state key in the S3 bucket
   tf_state_prefix = format("%s-%s", local.account_id, data.aws_region.current.name)
 }

--- a/modules/role/policies.tf
+++ b/modules/role/policies.tf
@@ -1,4 +1,5 @@
-// Base policy shared by all roles
+
+## Craft a IMA policy for all terraform roles
 data "aws_iam_policy_document" "base" {
   statement {
     actions = [
@@ -24,7 +25,7 @@ data "aws_iam_policy_document" "base" {
   }
 }
 
-// DynamoDB policy shared by terraform roles
+## Craft a IAM policy for access to the DynamoDB table 
 data "aws_iam_policy_document" "dynamo" {
   statement {
     actions = [
@@ -40,27 +41,7 @@ data "aws_iam_policy_document" "dynamo" {
   }
 }
 
-// Policy for terraform plan role
-data "aws_iam_policy_document" "tfstate_plan" {
-  source_policy_documents = [
-    data.aws_iam_policy_document.base.json,
-    data.aws_iam_policy_document.dynamo.json,
-  ]
-}
-
-resource "aws_iam_policy" "tfstate_plan" {
-  name        = format("%s-tfstate-plan", var.name)
-  description = "Policy allowing read access to the Terraform state bucket and DynamoDB table for the ${var.name} role"
-  policy      = data.aws_iam_policy_document.tfstate_plan.json
-  tags        = var.tags
-}
-
-resource "aws_iam_role_policy_attachment" "tfstate_plan" {
-  policy_arn = aws_iam_policy.tfstate_plan.arn
-  role       = aws_iam_role.ro.name
-}
-
-// Policy for terraform apply role
+## Craft an IAM policy with the necessary permissions for terraform apply 
 data "aws_iam_policy_document" "tfstate_apply" {
   source_policy_documents = [
     data.aws_iam_policy_document.base.json,
@@ -80,33 +61,18 @@ data "aws_iam_policy_document" "tfstate_apply" {
   }
 }
 
-resource "aws_iam_policy" "tfstate_apply" {
-  name        = format("%s-tfstate-apply", var.name)
-  description = "Policy allowing write access to the Terraform state bucket and DynamoDB table for the ${var.name} role"
-  policy      = data.aws_iam_policy_document.tfstate_apply.json
-  tags        = var.tags
+
+## Craft an IAM policy with the necessary permissions for terraform plan 
+data "aws_iam_policy_document" "tfstate_plan" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.base.json,
+    data.aws_iam_policy_document.dynamo.json,
+  ]
 }
 
-resource "aws_iam_role_policy_attachment" "tfstate_apply" {
-  policy_arn = aws_iam_policy.tfstate_apply.arn
-  role       = aws_iam_role.rw.name
-}
-
-// Policy for terraform remote state reading
+## Craft an IAM policy with the necessary permissions for terraform remote state
 data "aws_iam_policy_document" "tfstate_remote" {
   source_policy_documents = [
     data.aws_iam_policy_document.base.json,
   ]
-}
-
-resource "aws_iam_policy" "tfstate_remote" {
-  name        = format("%s-tfstate-remote", var.name)
-  description = "Policy allowing read access to the Terraform state bucket for the ${var.name} role"
-  policy      = data.aws_iam_policy_document.tfstate_remote.json
-  tags        = var.tags
-}
-
-resource "aws_iam_role_policy_attachment" "tfstate_remote" {
-  policy_arn = aws_iam_policy.tfstate_remote.arn
-  role       = aws_iam_role.sr.name
 }

--- a/modules/role/policies.tf
+++ b/modules/role/policies.tf
@@ -1,5 +1,5 @@
 
-## Craft a IMA policy for all terraform roles
+## Craft a IAM policy for all terraform roles
 data "aws_iam_policy_document" "base" {
   statement {
     actions = [

--- a/modules/role/variables.tf
+++ b/modules/role/variables.tf
@@ -107,6 +107,13 @@ variable "force_detach_policies" {
 variable "permission_boundary" {
   type        = string
   description = "The name of the policy that is used to set the permissions boundary for the IAM role"
+  default     = null
+}
+
+variable "permission_boundary_arn" {
+  type        = string
+  description = "The full ARN of the permission boundary to attach to the role"
+  default     = null
 }
 
 variable "tags" {


### PR DESCRIPTION
Currently we are creating iam policies for each of the plan, apply and remote state roles to access the terraform state and dynamodb. These policies are very specific and locked down to specific keys; I think it ok to have these inline with the role.

